### PR TITLE
Reorganize and cleanup to match Julia v1 conventions

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,1 @@
+style = "sciml"

--- a/src/QuasiTriangular.jl
+++ b/src/QuasiTriangular.jl
@@ -8,6 +8,10 @@ import Base.getindex
 import Base.require_one_based_indexing
 import Base.setindex!
 import Base.copy
+import Base.Matrix
+import Base.strides
+import Base.elsize
+import Base.unsafe_convert
 import LinearAlgebra.checksquare
 import LinearAlgebra.BlasInt
 import LinearAlgebra.BLAS.@blasfunc
@@ -71,6 +75,11 @@ function setindex!(A::QuasiUpperTriangular, x, i::Integer, j::Integer)
     end
     return A
 end
+
+## Implement StridedArray interface to be compatible with generic BLAS calls
+Base.strides(a::QuasiUpperTriangular{T, <: AbstractMatrix{T}}) where {T} = strides(a.data)
+Base.elsize(::Type{<:QuasiUpperTriangular{T, <: AbstractMatrix{T}}})  where T = Base.elsize(Matrix{T})
+Base.unsafe_convert(::Type{Ptr{T}}, a::QuasiUpperTriangular{T, <: AbstractMatrix{T}}) where {T} = pointer(a.data)
 
 ## Generic quasi triangular right vector, multiplication
 function A_mul_B!(a::QuasiUpperTriangular,b::AbstractVector,work::AbstractVector)

--- a/src/QuasiTriangular.jl
+++ b/src/QuasiTriangular.jl
@@ -8,10 +8,6 @@ import Base.getindex
 import Base.require_one_based_indexing
 import Base.setindex!
 import Base.copy
-import Base.Matrix
-import Base.strides
-import Base.elsize
-import Base.unsafe_convert
 import LinearAlgebra.checksquare
 import LinearAlgebra.BlasInt
 import LinearAlgebra.BLAS.@blasfunc
@@ -75,11 +71,6 @@ function setindex!(A::QuasiUpperTriangular, x, i::Integer, j::Integer)
     end
     return A
 end
-
-## Implement StridedArray interface to be compatible with generic BLAS calls
-Base.strides(a::QuasiUpperTriangular{T, <: AbstractMatrix{T}}) where {T} = strides(a.data)
-Base.elsize(::Type{<:QuasiUpperTriangular{T, <: AbstractMatrix{T}}})  where T = Base.elsize(Matrix{T})
-Base.unsafe_convert(::Type{Ptr{T}}, a::QuasiUpperTriangular{T, <: AbstractMatrix{T}}) where {T} = pointer(a.data)
 
 ## Generic quasi triangular right vector, multiplication
 function A_mul_B!(a::QuasiUpperTriangular,b::AbstractVector,work::AbstractVector)


### PR DESCRIPTION
Implement StridedArray interface for compatibility with BLAS/LAPACK operations.

This allows all QuasiTriangular matrisies to work with `LinearAlgebra.BLAS` operations or our ones in `ExtendedMul` (in fact both do a ccall to libblas)

I think this practically makes obsolete all A_mul_B functions except the ones that specify extra arguments (`ma`, `nc`, etc...) for submatrix operations. 

Reference: https://docs.julialang.org/en/v1/manual/interfaces/#man-interface-strided-arrays